### PR TITLE
Support Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+
+github "floriankrueger/ConsistencyManager-iOS" "carthage-support"

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 
-github "floriankrueger/ConsistencyManager-iOS" "carthage-support"
+github "linkedin/ConsistencyManager-iOS" ~> 2.0.0
+

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 
-github "linkedin/ConsistencyManager-iOS" ~> 2.0.0
-
+github "linkedin/ConsistencyManager-iOS"

--- a/README.md
+++ b/README.md
@@ -23,11 +23,23 @@ With Rocket Data, you can choose your own caching solution. We recommend a fast 
 
 ## Installation
 
+Installation via both [CocoaPods](https://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage) is supported.
+
+### CocoaPods
+
 Add this to your Podspec:
-```
+```ruby
 pod 'RocketData'
 ```
 Then run `pod install`.
+
+### Carthage
+
+Add this to your `Cartfile`:
+```ogdl
+github "linkedin/RocketData"
+```
+Then run `carthage update RocketData`
 
 ## Documentation
 


### PR DESCRIPTION
This commit adds a Cartfile that specifies the dependency to `ConsistencyManager-iOS`. The pull request is depending on the [ConsistencyManager-iOS-PR-32](https://github.com/linkedin/ConsistencyManager-iOS/pull/32) which provides better Carthage support.

For now, I've specified any version of the consistency manager compatible with 2.0.0 but you should better specify the next (minor?) release version that contains the PR listed above (s.th. like 2.0.1 but that's up to you and how you like to version).

If you want, I could also add installation instructions for Carthage to the Readme.

Thanks!
