### PR TITLE
Adding updateModel methods to data model manager which take a SimpleModel argument

### DIFF
--- a/RocketData.xcodeproj/project.pbxproj
+++ b/RocketData.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		612AB3E11CCE7C1C0034EADD /* PauseDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612AB3E01CCE7C1C0034EADD /* PauseDataProviderTests.swift */; };
 		612AB3E31CCE877D0034EADD /* PauseCollectionDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612AB3E21CCE877D0034EADD /* PauseCollectionDataProviderTests.swift */; };
 		612AB3E71CCE8AC30034EADD /* SharedCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612AB3E61CCE8AC30034EADD /* SharedCollectionTests.swift */; };
-		612B73621C8F9CD2005B12B1 /* ScherzoTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612B73611C8F9CD2005B12B1 /* ScherzoTestCase.swift */; };
+		612B73621C8F9CD2005B12B1 /* RocketDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612B73611C8F9CD2005B12B1 /* RocketDataTestCase.swift */; };
 		612B736D1C8FAF17005B12B1 /* SimpleCollectionDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612B736C1C8FAF17005B12B1 /* SimpleCollectionDataProviderTests.swift */; };
 		612B736F1C9079DC005B12B1 /* ConsistencyCollectionDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612B736E1C9079DC005B12B1 /* ConsistencyCollectionDataProviderTests.swift */; };
 		6137042E1CC91FAC008D0EBB /* WeakSharedCollectionArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6137042D1CC91FAC008D0EBB /* WeakSharedCollectionArrayTests.swift */; };
@@ -43,6 +43,7 @@
 		6175BEEA1C8F4BBD003A162D /* DataProviderDelegates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175BEE91C8F4BBD003A162D /* DataProviderDelegates.swift */; };
 		6192BEDB1CBFFC0A00212DC5 /* ChangeClockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6192BEDA1CBFFC0A00212DC5 /* ChangeClockTests.swift */; };
 		6192BEDD1CBFFDFB00212DC5 /* BatchListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6192BEDC1CBFFDFB00212DC5 /* BatchListenerTests.swift */; };
+		61B6660B1DB92CB600D9A812 /* DataModelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61B6660A1DB92CB500D9A812 /* DataModelManagerTests.swift */; };
 		61FD70A91C8E1BC800DFAD2E /* ParentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FD70A81C8E1BC800DFAD2E /* ParentModel.swift */; };
 		61FD70AB1C8E1BED00DFAD2E /* ChildModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FD70AA1C8E1BED00DFAD2E /* ChildModel.swift */; };
 		FA5D03BE8841FEDD5A3433AD /* Pods_RocketData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F416DEBD8929CFE59C87ED /* Pods_RocketData.framework */; };
@@ -85,7 +86,7 @@
 		612AB3E01CCE7C1C0034EADD /* PauseDataProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PauseDataProviderTests.swift; sourceTree = "<group>"; };
 		612AB3E21CCE877D0034EADD /* PauseCollectionDataProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PauseCollectionDataProviderTests.swift; sourceTree = "<group>"; };
 		612AB3E61CCE8AC30034EADD /* SharedCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedCollectionTests.swift; sourceTree = "<group>"; };
-		612B73611C8F9CD2005B12B1 /* ScherzoTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScherzoTestCase.swift; sourceTree = "<group>"; };
+		612B73611C8F9CD2005B12B1 /* RocketDataTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RocketDataTestCase.swift; sourceTree = "<group>"; };
 		612B736C1C8FAF17005B12B1 /* SimpleCollectionDataProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleCollectionDataProviderTests.swift; sourceTree = "<group>"; };
 		612B736E1C9079DC005B12B1 /* ConsistencyCollectionDataProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsistencyCollectionDataProviderTests.swift; sourceTree = "<group>"; };
 		6137042D1CC91FAC008D0EBB /* WeakSharedCollectionArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeakSharedCollectionArrayTests.swift; sourceTree = "<group>"; };
@@ -100,6 +101,7 @@
 		6192BEDA1CBFFC0A00212DC5 /* ChangeClockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeClockTests.swift; sourceTree = "<group>"; };
 		6192BEDC1CBFFDFB00212DC5 /* BatchListenerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BatchListenerTests.swift; sourceTree = "<group>"; };
 		6195AA441D413E8400F8BABB /* Pods_RocketData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_RocketData.framework; path = "../../../Library/Developer/Xcode/DerivedData/RocketData-fakibhwbjgxxqqbhtroabdzpzvve/Build/Products/Debug-iphonesimulator/Pods_RocketData.framework"; sourceTree = "<group>"; };
+		61B6660A1DB92CB500D9A812 /* DataModelManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataModelManagerTests.swift; sourceTree = "<group>"; };
 		61FD70A81C8E1BC800DFAD2E /* ParentModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParentModel.swift; sourceTree = "<group>"; };
 		61FD70AA1C8E1BED00DFAD2E /* ChildModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChildModel.swift; sourceTree = "<group>"; };
 		93F416DEBD8929CFE59C87ED /* Pods_RocketData.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RocketData.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -177,12 +179,13 @@
 		612242BF1C7B85D40017B0C4 /* RocketDataTests */ = {
 			isa = PBXGroup;
 			children = (
-				612B73611C8F9CD2005B12B1 /* ScherzoTestCase.swift */,
+				612B73611C8F9CD2005B12B1 /* RocketDataTestCase.swift */,
 				61FD70A71C8E1BB300DFAD2E /* TestModels */,
 				6175BEE41C8E3120003A162D /* TestHelpers */,
 				61FD70A51C8E1BB300DFAD2E /* CollectionDataProviderTests */,
 				61FD70A61C8E1BB300DFAD2E /* DataProviderTests */,
 				613C430D1CA091E00080B7A3 /* ParsingHelpersTests.swift */,
+				61B6660A1DB92CB500D9A812 /* DataModelManagerTests.swift */,
 				6192BEDA1CBFFC0A00212DC5 /* ChangeClockTests.swift */,
 				6192BEDC1CBFFDFB00212DC5 /* BatchListenerTests.swift */,
 				611562DA1CC16B490001F5CE /* CollectionChangeTests.swift */,
@@ -477,9 +480,10 @@
 				6175BEE31C8E30CF003A162D /* SimpleDataProviderTests.swift in Sources */,
 				612AB3E31CCE877D0034EADD /* PauseCollectionDataProviderTests.swift in Sources */,
 				61427D061D63CD800034617E /* SmallModels.swift in Sources */,
+				61B6660B1DB92CB600D9A812 /* DataModelManagerTests.swift in Sources */,
 				61FD70AB1C8E1BED00DFAD2E /* ChildModel.swift in Sources */,
 				611562DB1CC16B490001F5CE /* CollectionChangeTests.swift in Sources */,
-				612B73621C8F9CD2005B12B1 /* ScherzoTestCase.swift in Sources */,
+				612B73621C8F9CD2005B12B1 /* RocketDataTestCase.swift in Sources */,
 				611323AA1D5BB0070046625E /* FullChildModel.swift in Sources */,
 				6165455E1CC7E8F600AC68C9 /* CollectionChangeHelpers.swift in Sources */,
 				612AB3E11CCE7C1C0034EADD /* PauseDataProviderTests.swift in Sources */,
@@ -605,6 +609,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E816E0EC503C5F077273A5B3 /* Pods-RocketData.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -626,6 +631,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 997C3052192E11916F11C270 /* Pods-RocketData.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -646,7 +652,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AC288B6D02498F01FECDAA0F /* Pods-RocketDataTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = RocketDataTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.RocketDataTests;
@@ -659,7 +665,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E1E495CE9B06BB69A277C55E /* Pods-RocketDataTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				INFOPLIST_FILE = RocketDataTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = LinkedIn.RocketDataTests;

--- a/RocketData/DataModelManager.swift
+++ b/RocketData/DataModelManager.swift
@@ -60,6 +60,19 @@ open class DataModelManager {
     }
 
     /**
+     This function updates an individual model in only the consistency manager.
+     This will cause any data providers listening to this model change to update.
+     This is necessary because you can't call `updateModel` with an object of type SimpleModel.
+     This appears to be a Swift bug, but it is unclear.
+     
+     - parameter model: The model you want to update.
+     - parameter context: This context will be passed back to data provider delegates if this causes an update.
+     */
+    open func updateModelInConsistencyManager(_ model: SimpleModel, context: Any? = nil) {
+        consistencyManager.updateModel(model, context: ConsistencyContextWrapper(context: context))
+    }
+
+    /**
      This function updates an array of models in the consistency manager and cache.
      This will cause any data providers listening to this model change to update.
      Even if each model causes a different change in the data provider, it will still only receive one delegate callback with all the changes here.
@@ -80,6 +93,21 @@ open class DataModelManager {
                 }
             }
         }
+    }
+
+    /**
+     This function updates an array of models in only the consistency manager.
+     This will cause any data providers listening to this model change to update.
+     Even if each model causes a different change in the data provider, it will still only receive one delegate callback with all the changes here.
+     This is necessary because you can't call `updateModel` with an object of type SimpleModel.
+     This appears to be a Swift bug, but it is unclear.
+
+     - parameter models: The models you want to update.
+     - parameter context: This context will be passed back to data provider delegates if this causes an update.
+     */
+    open func updateModeslInConsistencyManager(_ models: [SimpleModel], context: Any? = nil) {
+        let batchModel = BatchUpdateModel(models: models.map { $0 as ConsistencyManagerModel })
+        consistencyManager.updateModel(batchModel, context: ConsistencyContextWrapper(context: context))
     }
 
     /**

--- a/RocketDataTests/CollectionDataProviderTests/ConsistencyCollectionDataProviderTests.swift
+++ b/RocketDataTests/CollectionDataProviderTests/ConsistencyCollectionDataProviderTests.swift
@@ -685,26 +685,24 @@ class ConsistencyCollectionDataProviderTests: RocketDataTestCase {
     // MARK: Timing Tests
 
     func testConsistencyManagerUpdateAfterSetData() {
-        func testDeletingModel() {
-            let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: DataModelManager.sharedDataManagerNoCache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: DataModelManager.sharedDataManagerNoCache)
 
-            // Let's create this before we do the setData. This ensures that this change happened before the setData.
-            let contextWrapper = ConsistencyContextWrapper(context: nil)
+        // Let's create this before we do the setData. This ensures that this change happened before the setData.
+        let contextWrapper = ConsistencyContextWrapper(context: nil)
 
-            let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
-            let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
 
-            let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
-                XCTFail()
-            }
-            dataProvider.delegate = delegate
-
-            dataProvider.setData([initialModel], cacheKey: nil, context: "wrong")
-            // This uses a date before the setData, so should be a no-op
-            DataModelManager.sharedDataManagerNoCache.consistencyManager.updateModel(newModel, context: contextWrapper)
-
-            waitForConsistencyManagerToFlush(DataModelManager.sharedDataManagerNoCache.consistencyManager)
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTFail()
         }
+        dataProvider.delegate = delegate
+
+        dataProvider.setData([initialModel], cacheKey: nil, context: "wrong")
+        // This uses a date before the setData, so should be a no-op
+        DataModelManager.sharedDataManagerNoCache.consistencyManager.updateModel(newModel, context: contextWrapper)
+
+        waitForConsistencyManagerToFlush(DataModelManager.sharedDataManagerNoCache.consistencyManager)
     }
 
     // MARK: Projection Tests

--- a/RocketDataTests/DataModelManagerTests.swift
+++ b/RocketDataTests/DataModelManagerTests.swift
@@ -1,0 +1,190 @@
+//
+//  DataModelManagerTests.swift
+//  RocketData
+//
+//  Created by Peter Livesey on 10/20/16.
+//  Copyright © 2016 LinkedIn. All rights reserved.
+//
+
+import XCTest
+import RocketData
+
+class DataModelManagerTests: RocketDataTestCase {
+    
+    func testUpdateModelWithCache() {
+        let cacheExpectation = expectation(description: "Wait for cache")
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        cache.setModelCalled = { model, key, context in
+            XCTAssertEqual(model as? ParentModel, newModel)
+            XCTAssertEqual(context as? String, "context")
+            XCTAssertEqual(key, "ParentModel:1")
+            cacheExpectation.fulfill()
+        }
+
+        dataProvider.setData([initialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModel(newModel, context: "context")
+
+        waitForExpectations(timeout: 10, handler: nil)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+    }
+
+    func testUpdateModelWithoutCache() {
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        cache.setModelCalled = { model, key, context in
+            XCTFail()
+        }
+
+        dataProvider.setData([initialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModel(newModel, updateCache: false, context: "context")
+
+        waitForCacheToFinish(dataModelManager)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+    }
+
+    func testUpdateModelInConsistencyManager() {
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        cache.setModelCalled = { model, key, context in
+            XCTFail()
+        }
+
+        dataProvider.setData([initialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModelInConsistencyManager(newModel, context: "context")
+
+        waitForCacheToFinish(dataModelManager)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+    }
+
+    func testUpdateModelsWithCache() {
+        let cacheExpectation = expectation(description: "Wait for cache")
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let otherInitialModel = ParentModel(id: 2, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+        let otherNewModel = ParentModel(id: 2, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        var setModelCalled = 0
+        cache.setModelCalled = { model, key, context in
+            setModelCalled += 1
+            XCTAssertEqual(model as? ParentModel, setModelCalled == 1 ? newModel : otherNewModel)
+            XCTAssertEqual(context as? String, "context")
+            XCTAssertEqual(key, "ParentModel:\(setModelCalled)")
+            if setModelCalled == 2 {
+                cacheExpectation.fulfill()
+            }
+        }
+
+        dataProvider.setData([initialModel, otherInitialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModels([newModel, otherNewModel], context: "context")
+
+        waitForExpectations(timeout: 10, handler: nil)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+        XCTAssertEqual(dataProvider[1], otherNewModel)
+    }
+
+    func testUpdateModelsWithoutCache() {
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let otherInitialModel = ParentModel(id: 2, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+        let otherNewModel = ParentModel(id: 2, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        cache.setModelCalled = { model, key, context in
+            XCTFail()
+        }
+
+        dataProvider.setData([initialModel, otherInitialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModels([newModel, otherNewModel], updateCache: false, context: "context")
+
+        waitForCacheToFinish(dataModelManager)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+        XCTAssertEqual(dataProvider[1], otherNewModel)
+    }
+
+    func testUpdateModelsInConsistencyManager() {
+        let cache = ExpectCacheDelegate()
+        let dataModelManager = DataModelManager(cacheDelegate: cache)
+        let dataProvider = CollectionDataProvider<ParentModel>(dataModelManager: dataModelManager)
+
+        let initialModel = ParentModel(id: 1, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let otherInitialModel = ParentModel(id: 2, name: "initial", requiredChild: ChildModel(), otherChildren: [])
+        let newModel = ParentModel(id: 1, name: "new", requiredChild: ChildModel(), otherChildren: [])
+        let otherNewModel = ParentModel(id: 2, name: "new", requiredChild: ChildModel(), otherChildren: [])
+
+        let delegate = ClosureCollectionDataProviderDelegate() { (collectionChanges, context) in
+            XCTAssertEqual(context as? String, "context")
+        }
+        dataProvider.delegate = delegate
+
+        cache.setModelCalled = { model, key, context in
+            XCTFail()
+        }
+
+        dataProvider.setData([initialModel, otherInitialModel], cacheKey: nil, context: "wrong")
+        dataModelManager.updateModeslInConsistencyManager([newModel, otherNewModel], context: "context")
+
+        waitForCacheToFinish(dataModelManager)
+        waitForConsistencyManagerToFlush(dataModelManager.consistencyManager)
+
+        XCTAssertEqual(dataProvider[0], newModel)
+        XCTAssertEqual(dataProvider[1], otherNewModel)
+    }
+}

--- a/RocketDataTests/RocketDataTestCase.swift
+++ b/RocketDataTests/RocketDataTestCase.swift
@@ -39,15 +39,15 @@ class RocketDataTestCase: XCTestCase {
      */
     func waitForCacheToFinish(_ dataModelManager: DataModelManager) {
         var expectation = self.expectation(description: "Wait for consistency manager to complete pending tasks")
-        (dataModelManager.externalDispatchQueue).async(flags: .barrier, execute: {
+        (dataModelManager.externalDispatchQueue).async(flags: .barrier) {
             expectation.fulfill()
-        }) 
+        }
         waitForExpectations(timeout: 10, handler: nil)
 
         expectation = self.expectation(description: "Wait for main thread to complete pending tasks")
-        DispatchQueue.main.async(flags: .barrier, execute: {
+        DispatchQueue.main.async(flags: .barrier) {
             expectation.fulfill()
-        }) 
+        }
         waitForExpectations(timeout: 10, handler: nil)
     }
     


### PR DESCRIPTION
This is to get around the fact that you cannot pass objects with type SimpleModel to the other updateModel functions
Adding tests for the new features and old features
