### PR TITLE
Update SampleApp to conform to new cache delegate protocol

### DIFF
--- a/RocketData/CacheDelegate.swift
+++ b/RocketData/CacheDelegate.swift
@@ -40,7 +40,7 @@ public protocol CacheDelegate {
      In this method, you should save a model in the cache.
      For information on threading, see the CacheDelegate docs.
      
-     - paramter model: The model to save in the cache.
+     - parameter model: The model to save in the cache.
      - parameter cacheKey: The cache key for this model. This is always equal to the modelIdentifier.
      - parameter context: A context you can pass in when saving to the cache.
      */
@@ -67,7 +67,7 @@ public protocol CacheDelegate {
      In this method, you should save a collection of models in the cache.
      For information on threading, see the CacheDelegate docs.
 
-     - paramter collection: The models to save in the cache. This is defined by the CollectionDataProvider.
+     - parameter collection: The models to save in the cache. This is defined by the CollectionDataProvider.
      - parameter cacheKey: The cache key for this model.
      - parameter context: A context you can pass in when saving to the cache.
      */

--- a/SampleApp/SampleApp/RocketDataHelpers/RocketDataCacheDelegate.swift
+++ b/SampleApp/SampleApp/RocketDataHelpers/RocketDataCacheDelegate.swift
@@ -32,7 +32,7 @@ class RocketDataCacheDelegate: CacheDelegate {
         completion(modelType.init(data: data) as? T, nil)
     }
 
-    func setModel<T : SimpleModel>(_ model: T, forKey cacheKey: String, context: Any?) {
+    func setModel(_ model: SimpleModel, forKey cacheKey: String, context: Any?) {
         if let model = model as? SampleAppModel {
             cache.setObject(model.data() as NSCoding, forKey: cacheKey, block: nil)
         } else {
@@ -62,7 +62,7 @@ class RocketDataCacheDelegate: CacheDelegate {
         completion(collection, nil)
     }
 
-    func setCollection<T : SimpleModel>(_ collection: [T], forKey cacheKey: String, context: Any?) {
+    func setCollection(_ collection: [SimpleModel], forKey cacheKey: String, context: Any?) {
         // In this method, we're going to store an array of strings for the collection and cache all the models individually
         // This means updating one of the models will automatically update the collection
 


### PR DESCRIPTION
PR #41 gets rid of generic functions for cache delegate setters -this makes the sample app's cache delegate conform to the new protocol.
