### PR TITLE
Updated Cartfile ConsistencyManager ref to 5.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "linkedin/ConsistencyManager-iOS" ~> 4.0.1
+github "linkedin/ConsistencyManager-iOS" ~> 5.0.0
 
 


### PR DESCRIPTION
Podfile was updated to 5.0.0 in a previous commit but Cartfile was not.