### PR TITLE
Fixes a Swift 4.1 warning

### DIFF
--- a/RocketData/BatchDataProviderListener.swift
+++ b/RocketData/BatchDataProviderListener.swift
@@ -129,7 +129,7 @@ public protocol BatchDataProviderListenerDelegate: class {
 
 public protocol BatchListenable: class {
     /// Allows the batch listener to set and read this property
-    weak var batchListener: BatchDataProviderListener? { get set }
+    var batchListener: BatchDataProviderListener? { get set }
     /**
      Returns true if the data provider actually updated to the current context.
      If the data provider ignored this change, the it will return false.


### PR DESCRIPTION
Not sure what the timeline on Swift 4.1 upgrade is, but this was an easy enough fix