### PR TITLE
block unnecessary work to improve performance

### DIFF
--- a/RocketData/BatchDataProviderListener.swift
+++ b/RocketData/BatchDataProviderListener.swift
@@ -30,7 +30,7 @@ open class BatchDataProviderListener: BatchListenerDelegate {
     open weak var delegate: BatchDataProviderListenerDelegate?
 
     /// The consistency manager which is backed by this instance
-    open let consistencyManager: ConsistencyManager
+    public let consistencyManager: ConsistencyManager
 
     /// This is the batch listener from the consistency manager which contains most of the logic for doing batch listening
     private let batchListener: BatchListener

--- a/RocketData/DataHolder.swift
+++ b/RocketData/DataHolder.swift
@@ -34,12 +34,14 @@ struct DataHolder<T> {
      This modifies the data in the data holder.
      - parameter data: The new data.
      - parameter changeTime: The new change time to set on lastUpdated.
+     - Returns: whether to successfully set the data
      */
-    mutating func setData(_ data: T, changeTime: ChangeTime) {
+    mutating func setData(_ data: T, changeTime: ChangeTime) -> Bool {
         if lastUpdated.after(changeTime) {
-            return
+            return false
         }
         self.data = data
         lastUpdated = changeTime
+        return true
     }
 }

--- a/RocketData/DataModelManager.swift
+++ b/RocketData/DataModelManager.swift
@@ -30,10 +30,10 @@ import ConsistencyManager
 open class DataModelManager {
 
     /// Cache Delegate. This is strongly retained since it is required by the library.
-    open let cacheDelegate: CacheDelegate
+    public let cacheDelegate: CacheDelegate
 
     /// Consistency Manager.
-    open let consistencyManager = ConsistencyManager()
+    public let consistencyManager = ConsistencyManager()
 
     let sharedCollectionManager = SharedCollectionManager()
 

--- a/RocketData/DataProvider.swift
+++ b/RocketData/DataProvider.swift
@@ -28,7 +28,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
     open weak var delegate: DataProviderDelegate?
 
     /// The data model manager which is backing this DataProvider
-    open let dataModelManager: DataModelManager
+    public let dataModelManager: DataModelManager
 
     /**
      You can set this variable to pause and unpause listening for changes to data.
@@ -129,7 +129,11 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
      or anything else you want.
     */
     open func setData(_ data: T?, updateCache: Bool = true, context: Any? = nil) {
-        self.dataHolder.setData(data, changeTime: ChangeTime())
+        let isSuccess = self.dataHolder.setData(data, changeTime: ChangeTime())
+        if !isSuccess {
+            return
+        }
+        
         if let data = data {
             if let cacheKey = data.modelIdentifier , updateCache {
                 dataModelManager.cacheModel(data, forKey: cacheKey, context: context)
@@ -171,7 +175,11 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
 
             if cacheDataFresh {
                 if let model = model {
-                    self.dataHolder.setData(model, changeTime: ChangeTime())
+                    let isSuccess = self.dataHolder.setData(model, changeTime: ChangeTime())
+                    if !isSuccess {
+                        return
+                    }
+                    
                     self.listenForUpdates()
                 }
                 completion(model, error)
@@ -261,7 +269,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
             // It will already have been updated in the cache so we don't need to recache it
             // We are also already listening to the new model so don't need to call listenForUpdates again
             // If we updated ourselves through Rocket Data, we'll always have a ChangeTime. Otherwise, let's use now.
-            dataHolder.setData(model, changeTime: changeTime)
+            _ = dataHolder.setData(model, changeTime: changeTime)
             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
         } else {
             Log.sharedInstance.assert(false, "Consistency manager returned an incorrect model type. It looks like we have duplicate ids for different classes. This is not allowed because models must have globally unique identifiers.")
@@ -285,7 +293,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
                                 // This signifies that this change should be discarded because it's out of date
                                 return
                             }
-                            dataHolder.setData(newModel, changeTime: changeTime)
+                            _ = dataHolder.setData(newModel, changeTime: changeTime)
                             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
                         }
                     }

--- a/RocketData/Logger.swift
+++ b/RocketData/Logger.swift
@@ -16,7 +16,7 @@ import Foundation
 open class Log {
 
     /// Singleton accessor
-    open static let sharedInstance = Log()
+    public static let sharedInstance = Log()
 
     /// Delegate for the class. If nil, then it will do default logging. Otherwise, it will leave it up to the delegate.
     open weak var delegate: LogDelegate?

--- a/RocketData/SharedCollectionManager.swift
+++ b/RocketData/SharedCollectionManager.swift
@@ -178,7 +178,7 @@ extension CollectionDataProvider: SharedCollection {
             listenForUpdates(model: batchModel)
 
             if !isPaused {
-                dataHolder.setData(newData, changeTime: ChangeTime())
+                _ = dataHolder.setData(newData, changeTime: ChangeTime())
                 updateDelegatesWithChange(.reset, context: context)
             } else {
                 lastPausedContext = context
@@ -206,7 +206,7 @@ extension CollectionDataProvider: SharedCollection {
 
                 var updatedData = data
                 updatedData.insert(contentsOf: newData, at: index)
-                dataHolder.setData(updatedData, changeTime: ChangeTime())
+                _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
                 // This should create an array of indexes starting at the insert point
                 // e.g. start with [x,y] insert two elements at index 1
@@ -237,7 +237,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData[index] = element
-            dataHolder.setData(updatedData, changeTime: ChangeTime())
+            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.update(index: index)]), context: context)
         } else {
@@ -254,7 +254,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData.remove(at: index)
-            dataHolder.setData(updatedData, changeTime: ChangeTime())
+            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.delete(index: index)]), context: context)
         } else {


### PR DESCRIPTION
In this pr, i do 2 things. The first one, I adapte the swift4 syntax to eliminate the warnings. The second one is performance improvement. Performance improvement as follow, when called dataHolder.setData(data, changeTime: ChangeTime()) method, if method return directly because of the conflict resolution mechanism，and code logic will continue to write data to the cache. In this case, it is unnecessary.