### PR TITLE
improve performance when has data conflicts

### DIFF
--- a/RocketData/BatchDataProviderListener.swift
+++ b/RocketData/BatchDataProviderListener.swift
@@ -30,7 +30,7 @@ open class BatchDataProviderListener: BatchListenerDelegate {
     open weak var delegate: BatchDataProviderListenerDelegate?
 
     /// The consistency manager which is backed by this instance
-    open let consistencyManager: ConsistencyManager
+    public let consistencyManager: ConsistencyManager
 
     /// This is the batch listener from the consistency manager which contains most of the logic for doing batch listening
     private let batchListener: BatchListener

--- a/RocketData/CollectionDataProvider.swift
+++ b/RocketData/CollectionDataProvider.swift
@@ -520,7 +520,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
 
         // If this update came from Rocket Data, change time will not be nil.
         // Otherwise, just use current time.
-        _ = dataHolder.setData(newData, changeTime: changeTime ?? ChangeTime())
+        dataHolder.setData(newData, changeTime: changeTime ?? ChangeTime())
 
         delegate?.collectionDataProviderHasUpdatedData(self, collectionChanges: collectionChanges, context: actualContext)
     }

--- a/RocketData/CollectionDataProvider.swift
+++ b/RocketData/CollectionDataProvider.swift
@@ -43,7 +43,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
     }
 
     /// The DataModelManager which backs this data provider.
-    open let dataModelManager: DataModelManager
+    public let dataModelManager: DataModelManager
 
     /// This saves the batchListener instance. It is public because it implements the BatchListenable protocol. You should never edit this directly.
     open weak var batchListener: BatchDataProviderListener?
@@ -129,7 +129,10 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
      anything else you want.
      */
     open func setData(_ data: [T], cacheKey: String?, shouldCache: Bool = true, context: Any? = nil) {
-        self.dataHolder.setData(data, changeTime: ChangeTime())
+        let isSuccess = self.dataHolder.setData(data, changeTime: ChangeTime())
+        if !isSuccess {
+            return
+        }
         self.cacheKey = cacheKey
         if shouldCache, let cacheKey = cacheKey {
             dataModelManager.cacheCollection(data, forKey: cacheKey, context: context)
@@ -193,7 +196,12 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
 
                     if cacheKey != self.cacheKey && cacheDataFresh {
                         if let collection = collection {
-                            self.dataHolder.setData(collection, changeTime: ChangeTime())
+                            let isSuccess = self.dataHolder.setData(collection, changeTime: ChangeTime())
+                            // If the method such as setData is not called from the main thread, there may still be conflicts. If so, just return
+                            if !isSuccess {
+                                return
+                            }
+                            
                             self.listenForUpdates()
                             self.cacheKey = cacheKey
                         }
@@ -220,8 +228,11 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
         if newData.count > 0 {
             var updatedData = data
             updatedData.insert(contentsOf: newData, at: index)
-            dataHolder.setData(updatedData, changeTime: ChangeTime())
-
+            let isSuccess = dataHolder.setData(updatedData, changeTime: ChangeTime())
+            if !isSuccess {
+                return
+            }
+            
             if shouldCache, let cacheKey = cacheKey {
                 dataModelManager.cacheCollection(data, forKey: cacheKey, context: context)
             }
@@ -267,7 +278,10 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
     open func update(_ element: T, at index: Int, shouldCache: Bool = true, context: Any? = nil) {
         var updatedData = data
         updatedData[index] = element
-        dataHolder.setData(updatedData, changeTime: ChangeTime())
+        let isSuccess = dataHolder.setData(updatedData, changeTime: ChangeTime())
+        if !isSuccess {
+            return
+        }
 
         if shouldCache, let cacheKey = cacheKey {
             self.dataModelManager.cacheCollection(data, forKey: cacheKey, context: context)
@@ -298,7 +312,10 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
     open func remove(at index: Int, shouldCache: Bool = true, context: Any? = nil) {
         var updatedData = data
         updatedData.remove(at: index)
-        dataHolder.setData(updatedData, changeTime: ChangeTime())
+        let isSuccess = dataHolder.setData(updatedData, changeTime: ChangeTime())
+        if !isSuccess {
+            return
+        }
 
         if shouldCache, let cacheKey = cacheKey {
             dataModelManager.cacheCollection(data, forKey: cacheKey, context: context)
@@ -327,7 +344,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
     - parameter dataModelManager: The data model manager to associate with this change.
     - parameter context: This context will be passed onto the cache delegate. Default nil.
     */
-    open static func setData(_ data: [T], cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil) {
+    public static func setData(_ data: [T], cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil) {
         let collectionDataProvider = CollectionDataProvider<T>(dataModelManager: dataModelManager)
         collectionDataProvider.setData(data, cacheKey: cacheKey, context: context)
     }
@@ -347,7 +364,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
      - parameter completion: This completion block is called when the insert has succeeded (but the data may not yet be propegated to the cache).
      If there is no data in the cache for this cacheKey, it will return an error as the insert has failed. Default nil.
      */
-    open static func insert(_ newData: [T], at index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
+    public static func insert(_ newData: [T], at index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
         let collectionDataProvider = CollectionDataProvider<T>(dataModelManager: dataModelManager)
         collectionDataProvider.fetchDataFromCache(withCacheKey: cacheKey) { cachedData, error in
             if let cachedData = cachedData {
@@ -370,7 +387,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
      - parameter completion: This completion block is called when the insert has succeeded (but the data may not yet be propegated to the cache).
      If there is no data in the cache for this cacheKey, it will return an error as the insert has failed. Default nil.
      */
-    open static func append(_ newData: [T], cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
+    public static func append(_ newData: [T], cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
         let collectionDataProvider = CollectionDataProvider<T>(dataModelManager: dataModelManager)
         collectionDataProvider.fetchDataFromCache(withCacheKey: cacheKey) { cachedData, error in
             collectionDataProvider.append(newData, context: context)
@@ -393,7 +410,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
      - parameter completion: This completion block is called when the insert has succeeded (but the data may not yet be propegated to the cache).
      If there is no data in the cache for this cacheKey, it will return an error as the insert has failed. Default nil.
      */
-    open static func update(_ element: T, at index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
+    public static func update(_ element: T, at index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
         let collectionDataProvider = CollectionDataProvider<T>(dataModelManager: dataModelManager)
         collectionDataProvider.fetchDataFromCache(withCacheKey: cacheKey) { cachedData, error in
             if let cachedData = cachedData {
@@ -417,7 +434,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
      - parameter completion: This completion block is called when the insert has succeeded (but the data may not yet be propegated to the cache).
      If there is no data in the cache for this cacheKey, it will return an error as the insert has failed. Default nil.
      */
-    open static func removeAtIndex(_ index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
+    public static func removeAtIndex(_ index: @escaping (([T])->Int), cacheKey: String, dataModelManager: DataModelManager, context: Any? = nil, completion: ((NSError?)->())? = nil) {
         let collectionDataProvider = CollectionDataProvider<T>(dataModelManager: dataModelManager)
         collectionDataProvider.fetchDataFromCache(withCacheKey: cacheKey) { cachedData, error in
             if let cachedData = cachedData {
@@ -503,7 +520,7 @@ open class CollectionDataProvider<T: SimpleModel>: ConsistencyManagerListener, B
 
         // If this update came from Rocket Data, change time will not be nil.
         // Otherwise, just use current time.
-        dataHolder.setData(newData, changeTime: changeTime ?? ChangeTime())
+        _ = dataHolder.setData(newData, changeTime: changeTime ?? ChangeTime())
 
         delegate?.collectionDataProviderHasUpdatedData(self, collectionChanges: collectionChanges, context: actualContext)
     }

--- a/RocketData/DataHolder.swift
+++ b/RocketData/DataHolder.swift
@@ -34,12 +34,14 @@ struct DataHolder<T> {
      This modifies the data in the data holder.
      - parameter data: The new data.
      - parameter changeTime: The new change time to set on lastUpdated.
+     - Returns: whether to successfully set the data
      */
-    mutating func setData(_ data: T, changeTime: ChangeTime) {
+    mutating func setData(_ data: T, changeTime: ChangeTime) -> Bool {
         if lastUpdated.after(changeTime) {
-            return
+            return false
         }
         self.data = data
         lastUpdated = changeTime
+        return true
     }
 }

--- a/RocketData/DataHolder.swift
+++ b/RocketData/DataHolder.swift
@@ -36,7 +36,7 @@ struct DataHolder<T> {
      - parameter changeTime: The new change time to set on lastUpdated.
      - Returns: whether to successfully set the data
      */
-    mutating func setData(_ data: T, changeTime: ChangeTime) -> Bool {
+    @discardableResult mutating func setData(_ data: T, changeTime: ChangeTime) -> Bool {
         if lastUpdated.after(changeTime) {
             return false
         }

--- a/RocketData/DataModelManager.swift
+++ b/RocketData/DataModelManager.swift
@@ -30,10 +30,10 @@ import ConsistencyManager
 open class DataModelManager {
 
     /// Cache Delegate. This is strongly retained since it is required by the library.
-    open let cacheDelegate: CacheDelegate
+    public let cacheDelegate: CacheDelegate
 
     /// Consistency Manager.
-    open let consistencyManager = ConsistencyManager()
+    public let consistencyManager = ConsistencyManager()
 
     let sharedCollectionManager = SharedCollectionManager()
 

--- a/RocketData/DataProvider.swift
+++ b/RocketData/DataProvider.swift
@@ -28,7 +28,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
     open weak var delegate: DataProviderDelegate?
 
     /// The data model manager which is backing this DataProvider
-    open let dataModelManager: DataModelManager
+    public let dataModelManager: DataModelManager
 
     /**
      You can set this variable to pause and unpause listening for changes to data.
@@ -129,7 +129,11 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
      or anything else you want.
     */
     open func setData(_ data: T?, updateCache: Bool = true, context: Any? = nil) {
-        self.dataHolder.setData(data, changeTime: ChangeTime())
+        let isSuccess = self.dataHolder.setData(data, changeTime: ChangeTime())
+        if !isSuccess {
+            return
+        }
+        
         if let data = data {
             if let cacheKey = data.modelIdentifier , updateCache {
                 dataModelManager.cacheModel(data, forKey: cacheKey, context: context)
@@ -171,7 +175,11 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
 
             if cacheDataFresh {
                 if let model = model {
-                    self.dataHolder.setData(model, changeTime: ChangeTime())
+                    let isSuccess = self.dataHolder.setData(model, changeTime: ChangeTime())
+                    if !isSuccess {
+                        return
+                    }
+                    
                     self.listenForUpdates()
                 }
                 completion(model, error)
@@ -261,7 +269,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
             // It will already have been updated in the cache so we don't need to recache it
             // We are also already listening to the new model so don't need to call listenForUpdates again
             // If we updated ourselves through Rocket Data, we'll always have a ChangeTime. Otherwise, let's use now.
-            dataHolder.setData(model, changeTime: changeTime)
+            _ = dataHolder.setData(model, changeTime: changeTime)
             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
         } else {
             Log.sharedInstance.assert(false, "Consistency manager returned an incorrect model type. It looks like we have duplicate ids for different classes. This is not allowed because models must have globally unique identifiers.")
@@ -285,7 +293,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
                                 // This signifies that this change should be discarded because it's out of date
                                 return
                             }
-                            dataHolder.setData(newModel, changeTime: changeTime)
+                            _ = dataHolder.setData(newModel, changeTime: changeTime)
                             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
                         }
                     }

--- a/RocketData/DataProvider.swift
+++ b/RocketData/DataProvider.swift
@@ -269,7 +269,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
             // It will already have been updated in the cache so we don't need to recache it
             // We are also already listening to the new model so don't need to call listenForUpdates again
             // If we updated ourselves through Rocket Data, we'll always have a ChangeTime. Otherwise, let's use now.
-            _ = dataHolder.setData(model, changeTime: changeTime)
+            dataHolder.setData(model, changeTime: changeTime)
             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
         } else {
             Log.sharedInstance.assert(false, "Consistency manager returned an incorrect model type. It looks like we have duplicate ids for different classes. This is not allowed because models must have globally unique identifiers.")
@@ -293,7 +293,7 @@ open class DataProvider<T: SimpleModel>: ConsistencyManagerListener, BatchListen
                                 // This signifies that this change should be discarded because it's out of date
                                 return
                             }
-                            _ = dataHolder.setData(newModel, changeTime: changeTime)
+                            dataHolder.setData(newModel, changeTime: changeTime)
                             delegate?.dataProviderHasUpdatedData(self, context: actualContext)
                         }
                     }

--- a/RocketData/Logger.swift
+++ b/RocketData/Logger.swift
@@ -16,7 +16,7 @@ import Foundation
 open class Log {
 
     /// Singleton accessor
-    open static let sharedInstance = Log()
+    public static let sharedInstance = Log()
 
     /// Delegate for the class. If nil, then it will do default logging. Otherwise, it will leave it up to the delegate.
     open weak var delegate: LogDelegate?

--- a/RocketData/SharedCollectionManager.swift
+++ b/RocketData/SharedCollectionManager.swift
@@ -178,7 +178,7 @@ extension CollectionDataProvider: SharedCollection {
             listenForUpdates(model: batchModel)
 
             if !isPaused {
-                dataHolder.setData(newData, changeTime: ChangeTime())
+                _ = dataHolder.setData(newData, changeTime: ChangeTime())
                 updateDelegatesWithChange(.reset, context: context)
             } else {
                 lastPausedContext = context
@@ -206,7 +206,7 @@ extension CollectionDataProvider: SharedCollection {
 
                 var updatedData = data
                 updatedData.insert(contentsOf: newData, at: index)
-                dataHolder.setData(updatedData, changeTime: ChangeTime())
+                _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
                 // This should create an array of indexes starting at the insert point
                 // e.g. start with [x,y] insert two elements at index 1
@@ -237,7 +237,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData[index] = element
-            dataHolder.setData(updatedData, changeTime: ChangeTime())
+            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.update(index: index)]), context: context)
         } else {
@@ -254,7 +254,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData.remove(at: index)
-            dataHolder.setData(updatedData, changeTime: ChangeTime())
+            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.delete(index: index)]), context: context)
         } else {

--- a/RocketData/SharedCollectionManager.swift
+++ b/RocketData/SharedCollectionManager.swift
@@ -178,7 +178,7 @@ extension CollectionDataProvider: SharedCollection {
             listenForUpdates(model: batchModel)
 
             if !isPaused {
-                _ = dataHolder.setData(newData, changeTime: ChangeTime())
+                dataHolder.setData(newData, changeTime: ChangeTime())
                 updateDelegatesWithChange(.reset, context: context)
             } else {
                 lastPausedContext = context
@@ -206,7 +206,7 @@ extension CollectionDataProvider: SharedCollection {
 
                 var updatedData = data
                 updatedData.insert(contentsOf: newData, at: index)
-                _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
+                dataHolder.setData(updatedData, changeTime: ChangeTime())
 
                 // This should create an array of indexes starting at the insert point
                 // e.g. start with [x,y] insert two elements at index 1
@@ -237,7 +237,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData[index] = element
-            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
+            dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.update(index: index)]), context: context)
         } else {
@@ -254,7 +254,7 @@ extension CollectionDataProvider: SharedCollection {
 
             var updatedData = data
             updatedData.remove(at: index)
-            _ = dataHolder.setData(updatedData, changeTime: ChangeTime())
+            dataHolder.setData(updatedData, changeTime: ChangeTime())
 
             updateDelegatesWithChange(.changes([.delete(index: index)]), context: context)
         } else {

--- a/SampleApp/Podfile.lock
+++ b/SampleApp/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - ConsistencyManager (6.0.0)
   - PINCache (2.3)
-  - RocketData (6.0.0):
+  - RocketData (6.0.1):
     - ConsistencyManager (~> 6.0.0)
 
 DEPENDENCIES:
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - RocketData (from `..`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - ConsistencyManager
     - PINCache
 
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ConsistencyManager: 10d92488107167a8d9df3cd93e529a15282ceaec
   PINCache: ce36ed282031b92fc7733ffe831f474ff80fddc2
-  RocketData: 407c9aeff026cf9281683717d78d26e15f6f8a98
+  RocketData: 2663345b70a12a0dcfb0752fb438c799866d450f
 
 PODFILE CHECKSUM: cb6653d292a93b194174111d0be6bb93b45e1b23
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/SampleApp/Pods/Local Podspecs/RocketData.podspec.json
+++ b/SampleApp/Pods/Local Podspecs/RocketData.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RocketData",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": {
     "type": "Apache License, Version 2.0"
   },
@@ -9,7 +9,7 @@
   "summary": "A non-blocking CoreData replacement which uses immutable models.",
   "source": {
     "git": "https://github.com/plivesey/RocketData.git",
-    "tag": "6.0.0"
+    "tag": "6.0.1"
   },
   "source_files": "RocketData/**/*.swift",
   "platforms": {

--- a/SampleApp/Pods/Manifest.lock
+++ b/SampleApp/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
   - ConsistencyManager (6.0.0)
   - PINCache (2.3)
-  - RocketData (6.0.0):
+  - RocketData (6.0.1):
     - ConsistencyManager (~> 6.0.0)
 
 DEPENDENCIES:
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - RocketData (from `..`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - ConsistencyManager
     - PINCache
 
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   ConsistencyManager: 10d92488107167a8d9df3cd93e529a15282ceaec
   PINCache: ce36ed282031b92fc7733ffe831f474ff80fddc2
-  RocketData: 407c9aeff026cf9281683717d78d26e15f6f8a98
+  RocketData: 2663345b70a12a0dcfb0752fb438c799866d450f
 
 PODFILE CHECKSUM: cb6653d292a93b194174111d0be6bb93b45e1b23
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.3

--- a/SampleApp/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
+++ b/SampleApp/Pods/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh
@@ -113,6 +113,6 @@ then
   if [ -z ${ASSETCATALOG_COMPILER_APPICON_NAME+x} ]; then
     printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
   else
-    printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_BUILD_DIR}/assetcatalog_generated_info.plist"
+    printf "%s\0" "${XCASSET_FILES[@]}" | xargs -0 xcrun actool --output-format human-readable-text --notices --warnings --platform "${PLATFORM_NAME}" --minimum-deployment-target "${!DEPLOYMENT_TARGET_SETTING_NAME}" ${TARGET_DEVICE_ARGS} --compress-pngs --compile "${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}" --app-icon "${ASSETCATALOG_COMPILER_APPICON_NAME}" --output-partial-info-plist "${TARGET_TEMP_DIR}/assetcatalog_generated_info_cocoapods.plist"
   fi
 fi

--- a/SampleApp/Pods/Target Support Files/RocketData/Info.plist
+++ b/SampleApp/Pods/Target Support Files/RocketData/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>6.0.0</string>
+  <string>6.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
In this pr, i do 2 things. The first one, I adapte the swift4 syntax to eliminate the warnings. The second one is performance improvement. Performance improvement as follow, when called dataHolder.setData(data, changeTime: ChangeTime()) method, if method return directly because of the conflict resolution mechanism，and code logic will continue to write data to the cache. In this case, it is unnecessary.